### PR TITLE
allow max_arg_length to be specified in as_string

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,7 @@
+
+- Allow arguments to a trace's as_string, specifically max_arg_length
+  Patch by Ricardo Signes.
+
 1.27  2011-01-16
 
 - Skip some tests on 5.13.8+ that are no longer relevant because of a change

--- a/lib/Devel/StackTrace.pm
+++ b/lib/Devel/StackTrace.pm
@@ -219,11 +219,12 @@ sub frame_count {
 
 sub as_string {
     my $self = shift;
+    my $arg  = shift;
 
     my $st    = '';
     my $first = 1;
     foreach my $f ( $self->frames() ) {
-        $st .= $f->as_string($first) . "\n";
+        $st .= $f->as_string($first, $arg) . "\n";
         $first = 0;
     }
 
@@ -416,10 +417,14 @@ first frame is 0 and negative indexes are allowed.
 
 Returns the number of frames in the trace object.
 
-=item * $trace->as_string
+=item * $trace->as_string (\%arg)
 
 Calls as_string on each frame from top to bottom, producing output
 quite similar to the Carp module's cluck/confess methods.
+
+The optional C<\%arg> parameter only has one useful option:  if given,
+C<max_arg_length> will determine how many arguments to each frame's call
+will be dumped.
 
 =back
 

--- a/lib/Devel/StackTrace/Frame.pm
+++ b/lib/Devel/StackTrace/Frame.pm
@@ -55,6 +55,7 @@ sub args {
 sub as_string {
     my $self  = shift;
     my $first = shift;
+    my $arg   = shift;
 
     my $sub = $self->subroutine;
 
@@ -103,9 +104,13 @@ sub as_string {
                 local $@;
 
                 eval {
-                    if ( $self->{max_arg_length}
-                        && length $_ > $self->{max_arg_length} ) {
-                        substr( $_, $self->{max_arg_length} ) = '...';
+                    my $max_arg_length = exists $arg->{max_arg_length}
+                                       ? $arg->{max_arg_length}
+                                       : $self->{max_arg_length};
+
+                    if ( $max_arg_length
+                        && length $_ > $max_arg_length ) {
+                        substr( $_, $max_arg_length ) = '...';
                     }
 
                     s/'/\\'/g;

--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -313,6 +313,17 @@ main::max_arg_length('abcdefghij...') called at $test_file_name line 308
 EOF
 
     is( $trace->as_string, $trace_text, 'trace text' );
+
+    my $trace_text_1 = <<"EOF";
+Trace begun at $test_file_name line 1021
+main::max_arg_length('abc...') called at $test_file_name line 308
+EOF
+
+    is(
+      $trace->as_string({ max_arg_length => 3 }),
+      $trace_text_1,
+      'trace text, max_arg_length = 3',
+    );
 }
 
 SKIP:


### PR DESCRIPTION
As discussed on IRC, this allows one to say `$trace->as_string({ max_arg_length => 0 })`
