### PR TITLE
Revert the ignore_package check 

### DIFF
--- a/lib/Devel/StackTrace.pm
+++ b/lib/Devel/StackTrace.pm
@@ -107,7 +107,7 @@ sub _make_frame_filter {
     my ( @i_pack_re, %i_class );
     if ( $self->{ignore_package} ) {
         $self->{ignore_package} = [ $self->{ignore_package} ]
-            unless eval { @{ $self->{ignore_package} } };
+            unless UNIVERSAL::isa( $self->{ignore_package}, 'ARRAY' );
 
         @i_pack_re
             = map { ref $_ ? $_ : qr/^\Q$_\E$/ } @{ $self->{ignore_package} };


### PR DESCRIPTION
The change in eb8547597f95095fd7655aef47eb40e6f661e24e breaks Plack::Middleware::StackTrace as reported by @tokuhirom because of the non-localized use of eval + $@. https://gist.github.com/4116116

Also the new code fails if `$self->{ignore_packages} = []` already. Revert it to UNIVERSAL::isa makes everything work fine.
