### PR TITLE
Add filter_frames_early option to filter frames before stringifying args

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,7 @@
 {{$NEXT}}
 
+- Add filter_frames_early option to filter frames before stringifying args.
+
 1.31   2014-01-16
 
 - No code changes, just doc updates, including documenting the as_string()

--- a/lib/Devel/StackTrace.pm
+++ b/lib/Devel/StackTrace.pm
@@ -37,6 +37,8 @@ sub new {
 sub _record_caller_data {
     my $self = shift;
 
+    my $filter = $self->{filter_frames_early} && $self->_make_frame_filter;
+
     # We exclude this method by starting one frame back.
     my $x = 1;
     while (
@@ -53,19 +55,20 @@ sub _record_caller_data {
 
         my @args;
 
-        unless ( $self->{no_args} ) {
-            @args = @DB::args;
+        @args = $self->{no_args} ? () : @DB::args;
 
-            if ( $self->{no_refs} ) {
-                @args = map { ref $_ ? $self->_ref_to_string($_) : $_ } @args;
-            }
+        my $raw = {
+            caller => \@c,
+            args => \@args,
+        };
+
+        next if $filter && !$filter->($raw);
+
+        if ( $self->{no_refs} ) {
+            $raw->{args} = [ map { ref $_ ? $self->_ref_to_string($_) : $_ } @{$raw->{args}} ];
         }
 
-        push @{ $self->{raw} },
-            {
-            caller => \@c,
-            args   => \@args,
-            };
+        push @{ $self->{raw} }, $raw;
     }
 }
 
@@ -89,11 +92,11 @@ sub _ref_to_string {
 sub _make_frames {
     my $self = shift;
 
-    my $filter = $self->_make_frame_filter;
+    my $filter = !$self->{filter_frames_early} && $self->_make_frame_filter;
 
     my $raw = delete $self->{raw};
     for my $r ( @{$raw} ) {
-        next unless $filter->($r);
+        next if $filter && ! $filter->($r);
 
         $self->_add_frame( $r->{caller}, $r->{args} );
     }
@@ -336,6 +339,13 @@ key are the subroutine arguments found in C<@DB::args>.
 
 The filter should return true if the frame should be included, or
 false if it should be skipped.
+
+=item * filter_frames_early => $boolean
+
+If this parameter is true, C<frame_filter> will be called as soon as
+the stacktrace is created, and before refs are stringified (if
+C<no_refs> is true), rather than being filtered lazily when
+L<Devel::StackTrace::Frame> objects are first needed.
 
 =item * ignore_package => $package_name OR \@package_names
 

--- a/t/08-filter-early.t
+++ b/t/08-filter-early.t
@@ -1,0 +1,28 @@
+use strict;
+use warnings;
+
+use Test::More;
+
+use Devel::StackTrace;
+
+{
+    my $trace = foo([]);
+    is( 0 + grep(ref,  map { $_->args } $trace->frames), 0, 'args stringified in trace' );
+}
+
+done_testing();
+
+sub foo {
+    return Devel::StackTrace->new(
+        frame_filter => sub {
+            my $frame = shift;
+            if ($frame->{caller}[3] eq "main::foo") {
+                ok( ref $frame->{args}[0], 'ref arg passed to filter');
+            }
+            1;
+        },
+        filter_frames_early => 1,
+        no_refs => 1,
+    );
+}
+


### PR DESCRIPTION
This allows the filter to inspect the raw arguments of the frame to
decide whether to include the frame, and also avoid unnecessary
stringification of unwanted frames' args.
