### PR TITLE
add skip_frames option

### DIFF
--- a/lib/Devel/StackTrace.pm
+++ b/lib/Devel/StackTrace.pm
@@ -41,6 +41,10 @@ sub _record_caller_data {
 
     # We exclude this method by starting one frame back.
     my $x = 1;
+    if ($self->{skip_frames}) {
+      $x += $self->{skip_frames};
+    }
+
     while (
         my @c
         = $self->{no_args}
@@ -364,6 +368,13 @@ Devel::StackTrace internally adds itself to the 'ignore_package'
 parameter, meaning that the Devel::StackTrace package is B<ALWAYS>
 ignored. However, if you create a subclass of Devel::StackTrace it
 will not be ignored.
+
+=item * skip_frames => $integer
+
+This number of stack frames will be excluded from top of the stack trace.
+This prevents the frames from being captured at all, and applies before the
+C<frame_filter>, C<ignore_package>, or C<ignore_class> options, even with
+C<filter_frames_early>.
 
 =item * no_refs => $boolean
 

--- a/t/09-skip-frames.t
+++ b/t/09-skip-frames.t
@@ -1,0 +1,41 @@
+use strict;
+use warnings;
+
+use Test::More;
+
+use Devel::StackTrace;
+
+{
+    my $trace = baz();
+    my @f;
+    while ( my $f = $trace->next_frame ) { push @f, $f; }
+
+    my $cnt = scalar @f;
+    is(
+        $cnt, 2,
+        "Trace should have 2 frames"
+    );
+
+    is(
+        $f[0]->subroutine, 'main::bar',
+        "First frame subroutine should be main::bar"
+    );
+    is(
+        $f[1]->subroutine, 'main::baz',
+        "First frame subroutine should be main::baz"
+    );
+}
+
+done_testing();
+
+sub foo {
+    return Devel::StackTrace->new(skip_frames => 2);
+}
+
+sub bar {
+    foo();
+}
+
+sub baz {
+    bar();
+}


### PR DESCRIPTION
The skip_frames option allows you to skip a number of frames at the top
of the stack from ever being collected.
