### PR TITLE
Replace no_refs option with unsafe_ref_capture option

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,10 @@
 {{$NEXT}}
 
+- Deprecated no_refs option, in favor of new unsafe_ref_capture option that
+  reverses behavior.  Capturing references by default caused too many issues
+  that couldn't be worked around, including possibly running DESTROY blocks
+  multiple times on captured objects.
+
 1.34   2014-06-26
 
 - Fixed use of // operator (my use, not Graham's) in previous release.

--- a/lib/Devel/StackTrace.pm
+++ b/lib/Devel/StackTrace.pm
@@ -17,10 +17,12 @@ sub new {
     my $class = shift;
     my %p     = @_;
 
-    # Backwards compatibility - this parameter was renamed to no_refs
-    # ages ago.
+    # Backwards compatibility - this parameter was renamed to no_refs, then
+    # to unsafe_ref_capture but with reversed behavior.
     $p{no_refs} = delete $p{no_object_refs}
         if exists $p{no_object_refs};
+    $p{unsafe_ref_capture} = ! delete $p{no_refs}
+        if exists $p{no_refs};
 
     my $self = bless {
         index  => undef,
@@ -65,7 +67,7 @@ sub _record_caller_data {
 
         next if $filter && !$filter->($raw);
 
-        if ( $self->{no_refs} ) {
+        if ( ! $self->{unsafe_ref_capture} ) {
             $raw->{args} = [ map { ref $_ ? $self->_ref_to_string($_) : $_ } @{$raw->{args}} ];
         }
 
@@ -344,9 +346,9 @@ false if it should be skipped.
 =item * filter_frames_early => $boolean
 
 If this parameter is true, C<frame_filter> will be called as soon as the
-stacktrace is created, and before refs are stringified (if C<no_refs> is
-true), rather than being filtered lazily when L<Devel::StackTrace::Frame>
-objects are first needed.
+stacktrace is created, and before refs are stringified (if
+C<unsafe_ref_capture> is not set), rather than being filtered lazily when
+L<Devel::StackTrace::Frame> objects are first needed.
 
 This is useful if you want to filter based on the frame's arguments and want
 to be able to examine object properties, for example.
@@ -373,13 +375,18 @@ stack trace. This prevents the frames from being captured at all, and applies
 before the C<frame_filter>, C<ignore_package>, or C<ignore_class> options,
 even with C<filter_frames_early>.
 
-=item * no_refs => $boolean
+=item * unsafe_ref_capture => $boolean
 
-If this parameter is true, then Devel::StackTrace will not store
-references internally when generating stacktrace frames. This lets
-your objects go out of scope.
+If this parameter is true, then Devel::StackTrace will store
+references internally when generating stacktrace frames.
 
-Devel::StackTrace replaces any references with their stringified
+B<This option is very dangerous, and should never be used with exception
+objects>.  Using this option will keep any objects or references alive past
+their normal lifetime, until the stack trace object goes out of scope.  It
+can keep objects alive even after their C<DESTROY> sub is called, resulting
+it it being called multiple times on the same object.
+
+If not set, Devel::StackTrace replaces any references with their stringified
 representation.
 
 =item * no_args => $boolean

--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -150,7 +150,7 @@ EOF
     );
 }
 
-# Storing references
+# Not storing references
 {
     my $obj = RefTest->new;
 
@@ -165,10 +165,13 @@ EOF
         "Only one argument should have been passed in the call to trace()"
     );
 
-    isa_ok( $args[0], 'RefTest' );
+    like(
+        $args[0], qr/RefTest=HASH/,
+        "Actual object should be replaced by string 'RefTest=HASH'"
+    );
 }
 
-# Not storing references
+# Storing references
 {
     my $obj = RefTest2->new;
 
@@ -183,15 +186,12 @@ EOF
         "Only one argument should have been passed in the call to trace()"
     );
 
-    like(
-        $args[0], qr/RefTest2=HASH/,
-        "Actual object should be replaced by string 'RefTest2=HASH'"
-    );
+    isa_ok( $args[0], 'RefTest2' );
 }
 
-# Not storing references (deprecated interface)
+# Storing references (deprecated interface 1)
 {
-    my $obj = RefTest3->new;
+    my $obj = RefTestDep1->new;
 
     my $trace = $obj->{trace};
 
@@ -204,10 +204,25 @@ EOF
         "Only one argument should have been passed in the call to trace()"
     );
 
-    like(
-        $args[0], qr/RefTest3=HASH/,
-        "Actual object should be replaced by string 'RefTest3=HASH'"
+    isa_ok( $args[0], 'RefTestDep1' );
+}
+
+# Storing references (deprecated interface 2)
+{
+    my $obj = RefTestDep2->new;
+
+    my $trace = $obj->{trace};
+
+    my $call_to_trace = ( $trace->frames )[1];
+
+    my @args = $call_to_trace->args;
+
+    is(
+        scalar @args, 1,
+        "Only one argument should have been passed in the call to trace()"
     );
+
+    isa_ok( $args[0], 'RefTestDep2' );
 }
 
 # No ref to Exception::Class::Base object without refs
@@ -309,14 +324,14 @@ if ( $Exception::Class::VERSION && $Exception::Class::VERSION >= 1.09 )
 
     my $trace_text = <<"EOF";
 Trace begun at $test_file_name line 1021
-main::max_arg_length('abcdefghij...') called at $test_file_name line 308
+main::max_arg_length('abcdefghij...') called at $test_file_name line 323
 EOF
 
     is( $trace->as_string, $trace_text, 'trace text' );
 
     my $trace_text_1 = <<"EOF";
 Trace begun at $test_file_name line 1021
-main::max_arg_length('abc...') called at $test_file_name line 308
+main::max_arg_length('abc...') called at $test_file_name line 323
 EOF
 
     is(
@@ -346,7 +361,7 @@ SKIP:
 
     ok(
         ( !grep { ref $_ } map { @{ $_->{args} } } @{ $trace->{raw} } ),
-        'raw data does not contain any references when no_refs is true'
+        'raw data does not contain any references when unsafe_ref_capture not set'
     );
 
     is(
@@ -418,7 +433,7 @@ sub baz {
 }
 
 sub quux {
-    Devel::StackTrace->new( no_refs => 1 );
+    Devel::StackTrace->new();
 }
 
 sub respect_overloading {
@@ -430,7 +445,7 @@ sub max_arg_length {
 }
 
 sub overload_no_stringify {
-    return Devel::StackTrace->new( no_refs => 1, respect_overload => 1 );
+    return Devel::StackTrace->new( respect_overload => 1 );
 }
 
 {
@@ -491,13 +506,13 @@ sub overload_no_stringify {
     }
 
     sub trace {
-        Devel::StackTrace->new( no_refs => 1 );
+        Devel::StackTrace->new( unsafe_ref_capture => 1 );
     }
 }
 
 {
     package    #hide
-        RefTest3;
+        RefTestDep1;
 
     sub new {
         my $self = bless {}, shift;
@@ -508,7 +523,24 @@ sub overload_no_stringify {
     }
 
     sub trace {
-        Devel::StackTrace->new( no_object_refs => 1 );
+        Devel::StackTrace->new( no_refs => 0 );
+    }
+}
+
+{
+    package    #hide
+        RefTestDep2;
+
+    sub new {
+        my $self = bless {}, shift;
+
+        $self->{trace} = trace($self);
+
+        return $self;
+    }
+
+    sub trace {
+        Devel::StackTrace->new( no_object_refs => 0 );
     }
 }
 
@@ -525,7 +557,7 @@ sub overload_no_stringify {
     }
 
     sub trace {
-        Devel::StackTrace->new( no_refs => 1 );
+        Devel::StackTrace->new();
     }
 }
 


### PR DESCRIPTION
Capturing refs causes too many options that can't be worked around
fully.  If used in an exception object, one of this module's most common
use cases, capturing objects will keep them alive for as long as the
exception object is alive.  This can cause issues with objects that
expect to be DESTROYed at a certain time.  Additionally, if thrown
inside a DESTROY sub, the exception object will keep the object being
destroyed alive until after the DESTROY sub finishes.  The exception
object will then be freed, and the DESTROY on the object will be called
again.

There is no reliable way to work around those issues, switch to not
capturing by default.  Rename the option controlling this from no_refs
to unsafe_ref_capture, but require it to be set true to capture refs.
The previous option will still work if set.
