### PR TITLE
Fix using frames as a setter

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 {{$NEXT}}
 
+- Fixed the frames method so when called with arguments it correctly sets the
+  frames even if the frames have not yet been read.  Patch by Mark Fowler.
+
 2.00   2014-11-01
 
 [BACKWARDS INCOMPATIBILITIES]

--- a/lib/Devel/StackTrace.pm
+++ b/lib/Devel/StackTrace.pm
@@ -222,6 +222,7 @@ sub frames {
             if grep { !$_->isa('Devel::StackTrace::Frame') } @_;
 
         $self->{frames} = \@_;
+        delete $self->{raw};
     }
     else {
         $self->_make_frames() if $self->{raw};

--- a/t/10-set-frames.t
+++ b/t/10-set-frames.t
@@ -1,0 +1,37 @@
+use strict;
+use warnings;
+
+use Test::More;
+
+use Devel::StackTrace;
+
+{
+    my $trace       = baz();
+    my $other_trace = bar();
+
+    $trace->frames( $other_trace->frames );
+
+    my @f;
+    while ( my $f = $trace->next_frame ) { push @f, $f; }
+
+    ok( @f == 1, 'only one frame' );
+
+    is(
+        $f[0]->subroutine, 'main::bar',
+        'First frame subroutine should be main::bar'
+    );
+}
+
+done_testing();
+
+sub foo {
+    return Devel::StackTrace->new( skip_frames => 2 );
+}
+
+sub bar {
+    foo();
+}
+
+sub baz {
+    bar();
+}


### PR DESCRIPTION
Setting the frames didn't clear the raw data structure, meaning that the
new value for frames would be mistakenly overwritten by the module
incorrectly converting the raw data structure the first time frames
were accessed even if they'd been manually set to some other value